### PR TITLE
Skip connection.setSendTimeAsDatetime when not available.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/jdbc_overrides.rb
+++ b/lib/active_record/connection_adapters/sqlserver/jdbc_overrides.rb
@@ -99,6 +99,7 @@ module ActiveRecord
 
         # Called to set any connection specific settings that aren't defined ahead of time
         def configure_connection
+          return unless @connection.connection.respond_to? :setSendTimeAsDatetime
           # For sql server 2008+ we want it to send an actual time otherwise comparisons with time columns don't work
           @connection.connection.setSendTimeAsDatetime(false)
         end


### PR DESCRIPTION
Was getting the following with Rails 5.0 and 5.1 

```
NoMethodError (undefined method `setSendTimeAsDatetime' for #<Java::ComMicrosoftSqlserverJdbc::SQLServerConnection:0x70ee1963>)
Did you mean?  sendTimeAsDatetime
```

Running `SELECT @@VERSION` against the db server returned 
`Microsoft SQL Server 2016 (SP2-CU7-GDR) (KB4505222) - 13.0.5366.0 (X64) `

This guard clause fixed it for me.