### PR TITLE
Load mssql jdbc driver with safety checks

### DIFF
--- a/lib/activerecord-jdbcsqlserver-adapter.rb
+++ b/lib/activerecord-jdbcsqlserver-adapter.rb
@@ -5,7 +5,7 @@ require 'active_support' # Need this for the next line
 require 'active_record/log_subscriber' # Need to make sure this is loaded before we load Core for monkey patching
 
 # Load the jar file for the jdbc driver
-require 'jdbc/mssql'
+require_relative './jdbc_mssql_driver_loader'
 
 # Standadard arjdbc functionality
 require 'arjdbc/abstract/connection_management'

--- a/lib/jdbc_mssql_driver_loader.rb
+++ b/lib/jdbc_mssql_driver_loader.rb
@@ -6,7 +6,7 @@ module JdbcMssqlDriverLoader
       which = driver
         .getClass().getClassLoader().loadClass(driver_name)
         .getProtectionDomain().getCodeSource().getLocation().to_s
-      warn "You alreday required a mssql jdbc driver (#{which}), skipping gem jdbc-mssql"
+      warn "You already required a mssql jdbc driver (#{which}), skipping gem jdbc-mssql"
 
       major_version = driver.major_version
       required_major_version = 8

--- a/lib/jdbc_mssql_driver_loader.rb
+++ b/lib/jdbc_mssql_driver_loader.rb
@@ -1,0 +1,22 @@
+module JdbcMssqlDriverLoader
+  def self.check_and_maybe_load_driver
+    driver_name = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+    if (Java::JavaClass.for_name(driver_name) rescue nil)
+      driver = Java::ComMicrosoftSqlserverJdbc::SQLServerDriver.new
+      which = driver
+        .getClass().getClassLoader().loadClass(driver_name)
+        .getProtectionDomain().getCodeSource().getLocation().to_s
+      warn "You alreday required a mssql jdbc driver (#{which}), skipping gem jdbc-mssql"
+
+      major_version = driver.major_version
+      required_major_version = 8
+      if major_version < required_major_version
+        raise "MSSQL jdbc driver version is to old (given major version #{major_version} < required major version #{required_major_version})"
+      end
+    else
+      require "jdbc/mssql"
+    end
+  end
+
+  check_and_maybe_load_driver
+end


### PR DESCRIPTION
First check if a jdbc driver is already loaded and then check if driver major version is sufficient.
Otherwise require "jdbc/mssql". Also see #4.